### PR TITLE
Dropping support updating docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,96 @@
+version: 2.0
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - v2-deps-
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - run:
+        name: upload coverage report
+        command: |
+           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
+               PATH=$HOME/.local/bin:$PATH
+               pip install --user codecov
+               coverage xml
+               ~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
+           fi
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: v2-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6.1
+        environment:
+          - TOXENV=checkqa
+          - UPLOAD_COVERAGE=0
+  py27dj111:
+    <<: *common
+    docker:
+      - image: circleci/python:2.7
+        environment:
+          TOXENV=py27-dj111
+  py34dj111:
+    <<: *common
+    docker:
+      - image: circleci/python:3.4
+        environment:
+          TOXENV=py34-dj111
+  py34dj20:
+    <<: *common
+    docker:
+      - image: circleci/python:3.4
+        environment:
+          TOXENV=py34-dj20
+  py35dj111:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV=py35-dj111
+  py35dj20:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV=py35-dj20
+  py36dj111:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj111
+  py36dj20:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj20
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py27dj111
+      - py34dj111
+      - py34dj20
+      - py35dj111
+      - py35dj20
+      - py36dj111
+      - py36dj20

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
+MANIFEST
 .DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 
-# C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -13,6 +12,7 @@ env/
 build/
 develop-eggs/
 dist/
+docs/_build/
 eggs/
 lib/
 lib64/
@@ -23,6 +23,11 @@ var/
 .installed.cfg
 *.egg
 *.eggs
+.python-version
+
+# Pipfile
+Pipfile
+Pipfile.lock
 
 # Installer logs
 pip-log.txt
@@ -36,12 +41,5 @@ htmlcov/
 nosetests.xml
 coverage.xml
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# MkDocs
-site/
+# IDEs
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,27 +1,61 @@
+![](http://pinaxproject.com/pinax-design/patches/pinax-forums.svg)
+
 # Pinax Forums
 
-[![](http://slack.pinaxproject.com/badge.svg)](http://slack.pinaxproject.com/)
-[![](https://img.shields.io/travis/pinax/pinax-forums.svg)](https://travis-ci.org/pinax/pinax-forums)
-[![](https://img.shields.io/coveralls/pinax/pinax-forums.svg)](https://coveralls.io/r/pinax/pinax-forums)
-[![](https://img.shields.io/pypi/dm/pinax-forums.svg)](https://pypi.python.org/pypi/pinax-forums/)
 [![](https://img.shields.io/pypi/v/pinax-forums.svg)](https://pypi.python.org/pypi/pinax-forums/)
-[![](https://img.shields.io/badge/license-MIT-blue.svg)](https://pypi.python.org/pypi/pinax-forums/)
 
-## Pinax
+[![CircleCi](https://img.shields.io/circleci/project/github/pinax/pinax-forums.svg)](https://circleci.com/gh/pinax/pinax-forums)
+[![Codecov](https://img.shields.io/codecov/c/github/pinax/pinax-forums.svg)](https://codecov.io/gh/pinax/pinax-forums)
+[![](https://img.shields.io/github/contributors/pinax/pinax-forums.svg)](https://github.com/pinax/pinax-forums/graphs/contributors)
+[![](https://img.shields.io/github/issues-pr/pinax/pinax-forums.svg)](https://github.com/pinax/pinax-forums/pulls)
+[![](https://img.shields.io/github/issues-pr-closed/pinax/pinax-forums.svg)](https://github.com/pinax/pinax-forums/pulls?q=is%3Apr+is%3Aclosed)
 
-Pinax is an open-source platform built on the Django Web Framework. It is an
-ecosystem of reusable Django apps, themes, and starter project templates.
-This collection can be found at http://pinaxproject.com.
+[![](http://slack.pinaxproject.com/badge.svg)](http://slack.pinaxproject.com/)
+[![](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-This app was developed as part of the Pinax ecosystem but is just a Django app
-and can be used independently of other Pinax apps.
 
+## Table of Contents
+
+* [About Pinax](#about-pinax)
+* [Overview](#overview)
+  * [Supported Django and Python versions](#supported-django-and-python-versions)
+* [Change Log](#change-log)
+* [History](#history)
+* [Contribute](#contribute)
+* [Code of Conduct](#code-of-conduct)
+* [Connect with Pinax](#connect-with-pinax)
+* [License](#license)
+
+## About Pinax
+
+Pinax is an open-source platform built on the Django Web Framework. It is an ecosystem of reusable
+Django apps, themes, and starter project templates. This collection can be found at http://pinaxproject.com.
 
 ## pinax-forums
+
+### Overview
 
 `pinax-forums` is an extensible forums app for Django and Pinax. It is focused
 on core forum functionality and hence is expected to be combined with other
 Pinax apps for broader features.
+
+#### Supported Django and Python versions
+
+Django \ Python | 2.7 | 3.4 | 3.5 | 3.6
+--------------- | --- | --- | --- | ---
+1.11 |  *  |  *  |  *  |  *  
+2.0  |     |  *  |  *  |  *
+
+
+## Change Log
+
+### 
+
+* Add Django 2.0 compatibility testing
+* Drop Django 1.8, 1.9, 1.10, and Python 3.3 support
+* Move documentation into README and standardize layout
+* Convert CI and coverage to CircleCi and CodeCov
+* Add PyPi-compatible long description
 
 
 ## History
@@ -32,27 +66,33 @@ The clients were kind enough to allow Eldarion to open source the app and
 contribute it to Pinax.
 
 
-## Documentation
-
-The `pinax-forums` documentation is currently under construction. If you would
-like to help us write documentation, please join our Pinax Project Slack team
-and let us know! The Pinax documentation is available at http://pinaxproject.com/pinax/.
-
-
 ## Contribute
 
-See [this blog post](http://blog.pinaxproject.com/2016/02/26/recap-february-pinax-hangout/) including a video, or our [How to Contribute](http://pinaxproject.com/pinax/how_to_contribute/) section for an overview on how contributing to Pinax works. For concrete contribution ideas, please see our [Ways to Contribute/What We Need Help With](http://pinaxproject.com/pinax/ways_to_contribute/) section.
+For an overview on how contributing to Pinax works read this [blog post](http://blog.pinaxproject.com/2016/02/26/recap-february-pinax-hangout/)
+and watch the included video, or read our [How to Contribute](http://pinaxproject.com/pinax/how_to_contribute/) section.
+For concrete contribution ideas, please see our
+[Ways to Contribute/What We Need Help With](http://pinaxproject.com/pinax/ways_to_contribute/) section.
 
-In case of any questions we recommend you [join our Pinax Slack team](http://slack.pinaxproject.com) and ping us there instead of creating an issue on GitHub. Creating issues on GitHub is of course also valid but we are usually able to help you faster if you ping us in Slack.
+In case of any questions we recommend you join our [Pinax Slack team](http://slack.pinaxproject.com)
+and ping us there instead of creating an issue on GitHub. Creating issues on GitHub is of course
+also valid but we are usually able to help you faster if you ping us in Slack.
 
-We also highly recommend reading our [Open Source and Self-Care blog post](http://blog.pinaxproject.com/2016/01/19/open-source-and-self-care/).  
+We also highly recommend reading our blog post on [Open Source and Self-Care](http://blog.pinaxproject.com/2016/01/19/open-source-and-self-care/).
 
 
 ## Code of Conduct
 
-In order to foster a kind, inclusive, and harassment-free community, the Pinax Project has a code of conduct, which can be found [here](http://pinaxproject.com/pinax/code_of_conduct/). We ask you to treat everyone as a smart human programmer that shares an interest in Python, Django, and Pinax with you.
+In order to foster a kind, inclusive, and harassment-free community, the Pinax Project
+has a [code of conduct](http://pinaxproject.com/pinax/code_of_conduct/).
+We ask you to treat everyone as a smart human programmer that shares an interest in Python, Django, and Pinax with you.
 
 
-## Pinax Project Blog and Twitter
+## Connect with Pinax
 
-For updates and news regarding the Pinax Project, please follow us on Twitter at @pinaxproject and check out our [blog]( http://blog.pinaxproject.com).
+For updates and news regarding the Pinax Project, please follow us on Twitter [@pinaxproject](https://twitter.com/pinaxproject)
+and check out our [Pinax Project blog](http://blog.pinaxproject.com).
+
+
+## License
+
+Copyright (c) 2012-2018 James Tauber and contributors under the [MIT license](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Django \ Python | 2.7 | 3.4 | 3.5 | 3.6
 
 ## Change Log
 
-### 
+### 1.0.0
 
 * Add Django 2.0 compatibility testing
 * Drop Django 1.8, 1.9, 1.10, and Python 3.3 support

--- a/pinax/forums/forms.py
+++ b/pinax/forums/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .models import ForumThread, ForumReply
+from .models import ForumReply, ForumThread
 
 
 class PostForm(object):

--- a/pinax/forums/hooks.py
+++ b/pinax/forums/hooks.py
@@ -1,4 +1,4 @@
-from django.utils.html import urlize, linebreaks, escape, conditional_escape
+from django.utils.html import conditional_escape, escape, linebreaks, urlize
 from django.utils.safestring import mark_safe
 
 from .conf import settings

--- a/pinax/forums/models.py
+++ b/pinax/forums/models.py
@@ -3,16 +3,15 @@ from __future__ import unicode_literals
 import datetime
 import json
 
-from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
-from django.contrib.auth import get_user_model
-
 from .conf import settings
-from .managers import ForumThreadManager
 from .hooks import hookset
+from .managers import ForumThreadManager
 
 
 # this is the glue to the activity events framework, provided as a no-op here

--- a/pinax/forums/models.py
+++ b/pinax/forums/models.py
@@ -23,7 +23,7 @@ def issue_update(kind, **kwargs):
 class ForumCategory(models.Model):
 
     title = models.CharField(max_length=100)
-    parent = models.ForeignKey("self", null=True, blank=True, related_name="subcategories")
+    parent = models.ForeignKey("self", null=True, blank=True, related_name="subcategories", on_delete=models.CASCADE)
 
     # @@@ total descendant forum count?
     # @@@ make group-aware
@@ -54,7 +54,8 @@ class Forum(models.Model):
         "self",
         null=True,
         blank=True,
-        related_name="subforums"
+        related_name="subforums",
+        on_delete=models.CASCADE
     )
     category = models.ForeignKey(
         ForumCategory,
@@ -238,7 +239,7 @@ class Forum(models.Model):
 
 class ForumPost(models.Model):
 
-    author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="%(app_label)s_%(class)s_related")
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="%(app_label)s_%(class)s_related", on_delete=models.CASCADE)
     content = models.TextField()
     content_html = models.TextField()
     created = models.DateTimeField(default=timezone.now, editable=False)
@@ -264,7 +265,7 @@ class ForumThread(ForumPost):
     # used for code that needs to know the kind of post this object is.
     kind = "thread"
 
-    forum = models.ForeignKey(Forum, related_name="threads")
+    forum = models.ForeignKey(Forum, related_name="threads", on_delete=models.CASCADE)
     title = models.CharField(max_length=100)
     last_modified = models.DateTimeField(
         default=timezone.now,
@@ -355,7 +356,7 @@ class ForumReply(ForumPost):
     # used for code that needs to know the kind of post this object is.
     kind = "reply"
 
-    thread = models.ForeignKey(ForumThread, related_name="replies")
+    thread = models.ForeignKey(ForumThread, related_name="replies", on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = "forum reply"
@@ -364,7 +365,7 @@ class ForumReply(ForumPost):
 
 class UserPostCount(models.Model):
 
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="post_count")
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="post_count", on_delete=models.CASCADE)
     count = models.IntegerField(default=0)
 
     @classmethod
@@ -387,8 +388,8 @@ class UserPostCount(models.Model):
 
 class ThreadSubscription(models.Model):
 
-    thread = models.ForeignKey(ForumThread, related_name="subscriptions")
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="forum_subscriptions")
+    thread = models.ForeignKey(ForumThread, related_name="subscriptions", on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="forum_subscriptions", on_delete=models.CASCADE)
     kind = models.CharField(max_length=15)
 
     class Meta:

--- a/pinax/forums/receivers.py
+++ b/pinax/forums/receivers.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
-from .models import ForumThread, ForumReply, ThreadSubscription, UserPostCount
+from .models import ForumReply, ForumThread, ThreadSubscription, UserPostCount
 
 
 @receiver(post_save, sender=ForumThread)

--- a/pinax/forums/templatetags/pinax_forums_tags.py
+++ b/pinax/forums/templatetags/pinax_forums_tags.py
@@ -1,8 +1,7 @@
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from ..models import ThreadSubscription
-
 
 register = template.Library()
 

--- a/pinax/forums/tests/urls.py
+++ b/pinax/forums/tests/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
 
-
 urlpatterns = (
     url(r"^", include("pinax.forums.urls", namespace="pinax_forums")),
 )

--- a/pinax/forums/urls.py
+++ b/pinax/forums/urls.py
@@ -1,18 +1,17 @@
 from django.conf.urls import url
 
 from .views import (
-    forums,
-    forum_category,
     forum,
+    forum_category,
     forum_thread,
+    forums,
     post_create,
-    reply_create,
     post_edit,
+    reply_create,
     subscribe,
-    unsubscribe,
     thread_updates,
+    unsubscribe,
 )
-
 
 # Expected that these are mounted under namespace "pinax_forums"
 urlpatterns = [

--- a/pinax/forums/urls.py
+++ b/pinax/forums/urls.py
@@ -13,6 +13,8 @@ from .views import (
     unsubscribe,
 )
 
+app_name = "pinax_forums"
+
 # Expected that these are mounted under namespace "pinax_forums"
 urlpatterns = [
     url(r"^$", forums, name="forums"),

--- a/pinax/forums/views.py
+++ b/pinax/forums/views.py
@@ -1,12 +1,11 @@
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, Http404
-from django.shortcuts import get_object_or_404, render
-
 from django.contrib import messages
+from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 
 from account.decorators import login_required
 
-from .forms import ThreadForm, ReplyForm
+from .forms import ReplyForm, ThreadForm
 from .hooks import hookset
 from .models import (
     Forum,
@@ -14,7 +13,7 @@ from .models import (
     ForumReply,
     ForumThread,
     ThreadSubscription,
-    UserPostCount
+    UserPostCount,
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,38 @@
 from setuptools import find_packages, setup
 
-
+VERSION = "1.0.0"
 LONG_DESCRIPTION = """
+.. image:: http://pinaxproject.com/pinax-design/patches/pinax-forums.svg
+    :target: https://pypi.python.org/pypi/pinax-forums/
+
 ============
 Pinax Forums
 ============
-.. image:: http://slack.pinaxproject.com/badge.svg
-   :target: http://slack.pinaxproject.com/
-
-.. image:: https://img.shields.io/travis/pinax/pinax-forums.svg
-    :target: https://travis-ci.org/pinax/pinax-forums
-
-.. image:: https://img.shields.io/coveralls/pinax/pinax-forums.svg
-    :target: https://coveralls.io/r/pinax/pinax-forums
-
-.. image:: https://img.shields.io/pypi/dm/pinax-forums.svg
-    :target:  https://pypi.python.org/pypi/pinax-forums/
 
 .. image:: https://img.shields.io/pypi/v/pinax-forums.svg
-    :target:  https://pypi.python.org/pypi/pinax-forums/
+    :target: https://pypi.python.org/pypi/pinax-forums/
 
+\ 
+
+.. image:: https://img.shields.io/circleci/project/github/pinax/pinax-forums.svg
+    :target: https://circleci.com/gh/pinax/pinax-forums
+.. image:: https://img.shields.io/codecov/c/github/pinax/pinax-forums.svg
+    :target: https://codecov.io/gh/pinax/pinax-forums
+.. image:: https://img.shields.io/github/contributors/pinax/pinax-forums.svg
+    :target: https://github.com/pinax/pinax-forums/graphs/contributors
+.. image:: https://img.shields.io/github/issues-pr/pinax/pinax-forums.svg
+    :target: https://github.com/pinax/pinax-forums/pulls
+.. image:: https://img.shields.io/github/issues-pr-closed/pinax/pinax-forums.svg
+    :target: https://github.com/pinax/pinax-forums/pulls?q=is%3Apr+is%3Aclosed
+
+\ 
+
+.. image:: http://slack.pinaxproject.com/badge.svg
+    :target: http://slack.pinaxproject.com/
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
-    :target:  https://pypi.python.org/pypi/pinax-forums/
+    :target: https://pypi.python.org/pypi/pinax-forums/
 
-
-Pinax
-------
-
-Pinax is an open-source platform built on the Django Web Framework. It is an
-ecosystem of reusable Django apps, themes, and starter project templates.
-This collection can be found at http://pinaxproject.com.
-
-This app was developed as part of the Pinax ecosystem but is just a Django app
-and can be used independently of other Pinax apps.
-
-
-pinax-forums
--------------
+\ 
 
 ``pinax-forums`` is an extensible forums app for Django and Pinax. It is
 focused on core forum functionality and hence is expected to be combined with
@@ -44,28 +40,41 @@ other Pinax apps for broader features.
 
 See ``pinax-project-forums`` for a full Django project incorporating numerous
 apps with the goal of providing an out of the box forums solution.
+
+Supported Django and Python Versions
+------------------------------------
+
++-----------------+-----+-----+-----+-----+
+| Django / Python | 2.7 | 3.4 | 3.5 | 3.6 |
++=================+=====+=====+=====+=====+
+|  1.11           |  *  |  *  |  *  |  *  |
++-----------------+-----+-----+-----+-----+
+|  2.0            |     |  *  |  *  |  *  |
++-----------------+-----+-----+-----+-----+
 """
 
-
 setup(
-    name="pinax-forums",
-    version="1.0.0",
     author="Pinax Team",
-    author_email="team@pinaxproject.com",
+    author_email="team@pinaxprojects.com",
     description="an extensible forum app for Django and Pinax",
+    name="pinax-forums",
     long_description=LONG_DESCRIPTION,
+    version=VERSION,
+    url="http://github.com/pinax/pinax-forums/",   
     license="MIT",
-    url="http://github.com/pinax/pinax-forums/",
     packages=find_packages(),
+    package_data={
+        "forums": []
+    },
     install_requires=[
         "django-appconf>=1.0.1",
-        "django-user-accounts==2.0.0"
+        "django-user-accounts==2.0.3"
     ],
     test_suite="runtests.runtests",
     tests_require=[
         "django-appconf>=1.0.1",
         "Django>=1.8",
-        "django-user-accounts==2.0.0"
+        "django-user-accounts==2.0.3"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,21 @@ setup(
         "django-user-accounts==2.0.0"
     ],
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
+        "Framework :: Django",
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Framework :: Django",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,28 +2,56 @@
 ignore = E265,E501
 max-line-length = 100
 max-complexity = 10
-exclude = migrations/*,docs/*
+exclude = **/*/migrations/*
+inline-quotes = double
+
+[isort]
+multi_line_output=3
+known_django=django
+known_third_party=pinax,account,appconf
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+include_trailing_comma=True
+skip_glob=**/*/migrations/*
+
+[coverage:run]
+source = pinax
+omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*
+branch = true
+data_file = .coverage
+
+[coverage:report]
+omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*
+exclude_lines =
+    coverage: omit
+show_missing = True
 
 [tox]
 envlist =
-    py27-{1.8,1.9,1.10,master},
-    py33-{1.8},
-    py34-{1.8,1.9,1.10,master},
-    py35-{1.8,1.9,1.10,master}
+    checkqa,
+    py27-dj{111}
+    py34-dj{111,20}
+    py35-dj{111,20}
+    py36-dj{111,20}
 
 [testenv]
+passenv = CI CIRCLECI CIRCLE_*
 deps =
-    coverage==4.0.3
-    flake8==2.5.4
-    1.8: Django>=1.8,<1.9
-    1.9: Django>=1.9,<1.10
-    1.10: Django>=1.10,<1.11
+    coverage
+    codecov
+    dj111: Django>=1.11,<1.12
+    dj20: Django<2.1
     master: https://github.com/django/django/tarball/master
+
 usedevelop = True
-setenv =
-   LANG=en_US.UTF-8
-   LANGUAGE=en_US:en
-   LC_ALL=en_US.UTF-8
+commands =
+    coverage run setup.py test
+    coverage report -m --skip-covered
+
+[testenv:checkqa]
 commands =
     flake8 pinax
-    coverage run setup.py test
+    isort --recursive --check-only --diff pinax -sp tox.ini
+deps =
+    flake8 == 3.4.1
+    flake8-quotes == 0.11.0
+    isort == 4.2.15


### PR DESCRIPTION
* Add Django 2.0 compatibility testing
* Drop Django 1.8, 1.9, 1.10, and Python 3.3 support
* Move documentation into README and standardize layout
* Convert CI and coverage to CircleCi and CodeCov
* Add PyPi-compatible long description